### PR TITLE
Add check for id created by sync function

### DIFF
--- a/R/sync.R
+++ b/R/sync.R
@@ -136,7 +136,7 @@ latticeView <- function(...,
                 Array.prototype.map.call(
                  document.querySelectorAll(".leaflet"),
                    function(ldiv){
-                     if (ldiv.id.indexOf("htmlwidget-") !== -1) {
+                     if (HTMLWidgets.find("#" + ldiv.id) && HTMLWidgets.find("#" + ldiv.id).getMap()) {
                         leaf_widgets[ldiv.id] = HTMLWidgets.find("#" + ldiv.id).getMap();
                      }
                    }

--- a/R/sync.R
+++ b/R/sync.R
@@ -136,7 +136,9 @@ latticeView <- function(...,
                 Array.prototype.map.call(
                  document.querySelectorAll(".leaflet"),
                    function(ldiv){
-                     leaf_widgets[ldiv.id] = HTMLWidgets.find("#" + ldiv.id).getMap();
+                     if (ldiv.id.indexOf("htmlwidget-") !== -1) {
+                        leaf_widgets[ldiv.id] = HTMLWidgets.find("#" + ldiv.id).getMap();
+                     }
                    }
                 );
                ',


### PR DESCRIPTION
I found that the sync function returns an error if there is another leaflet object in a different dashboard tab due to the .getMap() method being applied to a map not actually rendered (I can send you an example if need be). 

Thus the fix is to check the widget id contains the substring defined above.

I'm aware this might not be the most stable fix for this but seems to work ok for me.