### PR TITLE
svglite for popupSVGraph; not fully tested

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,7 +40,8 @@ Imports:
     webshot,
     viridisLite,
     sf,
-    base64enc
+    base64enc,
+    svglite
 LinkingTo: Rcpp
 RoxygenNote: 6.0.1
 SystemRequirements: GNU make

--- a/R/popup.R
+++ b/R/popup.R
@@ -286,22 +286,40 @@ popupGraph = function(graphs, type = c("png", "svg", "html"),
 
 
 ### svg -----
-popupSVGraph = function(graphs, dsn = tempdir(),
+popupSVGraph = function(graphs, #dsn = tempdir(),
                          width = 300, height = 300, ...) {
   lapply(1:length(graphs), function(i) {
-    nm = paste0("tmp_", i, ".svg")
-    fls = file.path(dsn, nm)
+    #nm = paste0("tmp_", i, ".svg")
+    #fls = file.path(dsn, nm)
 
     inch_wdth = width / 72
     inch_hght = height  / 72
 
-    svg(filename = fls, width = inch_wdth, height = inch_hght, ...)
+    #svg(filename = fls, width = inch_wdth, height = inch_hght, ...)
+    #print(graphs[[i]])
+    #dev.off()
+    lns <- svglite::svgstring(
+      width = inch_wdth,
+      height = inch_hght,
+      standalone = FALSE
+    )
     print(graphs[[i]])
     dev.off()
 
-    lns = paste(readLines(fls), collapse = "")
+    #lns = paste(readLines(fls), collapse = "")
     # file.remove(fls)
-    return(lns)
+    return(
+sprintf(
+"
+<div style='width: %dpx; height: %dpx;'>
+%s
+</div>
+" ,
+  width,
+  height,
+  lns()
+)
+    )
   })
 }
 


### PR DESCRIPTION
`svglite` is the only SVG creation solution in `R` which uses unique `id` (see https://github.com/r-lib/svglite/issues/67) so using it should solve #117.  We also don't need to deal with a bunch of `tempfile()`.  As stated, this is not fully tested. but works with code from #117 and documentation example.

![image](https://user-images.githubusercontent.com/837910/34754583-488831fe-f584-11e7-8c54-4c6a27d805e3.png)

This does add `svglite` as a dependency, but we might be able to just do `SUGGESTS`.
  