### PR TITLE
fix bug in addImageQuery with Shiny

### DIFF
--- a/R/extensions.R
+++ b/R/extensions.R
@@ -723,7 +723,8 @@ addImageQuery = function(map,
   ctrlid = ctrlid[imctrl]
 
   if (length(ctrlid) == 0) {
-    map = addControl(map, NULL, layerId = 'imageValues', position = position)
+    # must add empty character instead of NULL for html with addControl
+    map = addControl(map, html = "", layerId = 'imageValues', position = position)
   }
 
   map$dependencies <- c(map$dependencies,


### PR DESCRIPTION
`addControl()` fails when `html = NULL` when using with Shiny.  Fix by supplying html `""` rather than `NULL` to `addControl()`.  To be precise, this error can be traced to [leaflet line](https://github.com/rstudio/leaflet/blob/8cb7cfeef81d0b122269017535a2129cf0d18872/javascript/src/methods.js#L649).

 ref https://github.com/r-spatial/mapedit/issues/74