### PR TITLE
Travis: Fix rcmdcheck false positives

### DIFF
--- a/tic.R
+++ b/tic.R
@@ -4,7 +4,8 @@ get_stage("install") %>%
   # install lwgeom with its own library since linking again postgis source install fails sometimes
   add_code_step(install.packages("lwgeom", configure.args="--without-liblwgeom")) %>% # normal installation does not work
   add_code_step(remotes::install_github("r-spatial/stars")) %>%
-  add_code_step(remotes::install_github("hrbrmstr/albersusa"))
+  add_code_step(remotes::install_github("hrbrmstr/albersusa")) %>%
+  add_code_step(devtools::install_github("pat-s/rcmdcheck@catch-test-errors"))
 
 ###
 # deploy pkgdowm site


### PR DESCRIPTION
This catches errors in the test during `rcmdcheck`. Before test errors still triggered a green build (i.e. false positive) because due to some regex problems `rcmdcheck` did not catch the "ERROR" term.

Temporary workaround until this is fixed in master of `rcmdcheck`. See https://github.com/r-lib/rcmdcheck/issues/69