### PR TITLE
legend.R: take into account multiple class inheritance for factor values

### DIFF
--- a/R/color.R
+++ b/R/color.R
@@ -197,8 +197,15 @@ zcolColors <- function(x, # a vector, not a sp or sf object
   # }
 
   if (is.character(x)) x <- as.factor(x)
-  nint = length(levels(x))
-  rng = range(seq_along(levels(x)), na.rm = TRUE)
+
+  if (is.factor(x)) {
+    nint = length(levels(x))
+    rng = range(seq_along(levels(x)), na.rm = TRUE)
+  } else {
+    nint = length(unique(x))
+    rng = range(x, na.rm = TRUE)
+  }
+
 
   x <- as.numeric(x)
 

--- a/R/legend.R
+++ b/R/legend.R
@@ -158,7 +158,11 @@ mapviewLegend <- function(values,
   }
 
   function(map) {
-    switch(class(values),
+
+    # if values inherits from more than one class, select
+    value.class = class(values)[length(class(values))]
+
+    switch(value.class,
            factor = factorLegend(map,
                                  position = position,
                                  values = values,


### PR DESCRIPTION
Hi Tim,

@miribuss and I found a little bug:
When zcol is a ordered factor, the fuction `mapviewLegend` fails, as `class(values)` returns a vector of length > 1, which causes `switch()` to crash. 

``` r
library(mapview)

breweries$class = cut(breweries$number.of.types, 
                      breaks = c(0, 5, 10, 15),
                      labels = c("small", "medium", "large"))

mapview(breweries, zcol = "class")
```

![](https://i.imgur.com/qeqvysp.png)

``` r

breweries$ord.class = cut(breweries$number.of.types, 
                      breaks = c(0, 5, 10, 15),
                      labels = c("small", "medium", "large"), 
                      ordered_result = TRUE)

mapview(breweries, zcol = "ord.class")
#> Error in switch(class(values), factor = factorLegend(map, position = position, : EXPR must be a length 1 vector
```

<sup>Created on 2019-10-29 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>


Not sure, if our solution is appropriate for all different kinds of value vector types. Feel free to modify this ;)

Cheers, Christoph


