### PR TITLE
Use S3 methods to dispatch checkAdjustProjection

### DIFF
--- a/R/projection.R
+++ b/R/projection.R
@@ -11,31 +11,30 @@ wrong_proj_warning <-
 
 # Check and potentially adjust projection of objects to be rendered =======
 checkAdjustProjection <- function(x, method = "bilinear") {
-
-  x <- switch(class(x)[1],
-              "RasterLayer" = rasterCheckAdjustProjection(x, method),
-              "RasterStack" = rasterCheckAdjustProjection(x, method),
-              "RasterBrick" = rasterCheckAdjustProjection(x, method),
-              "SpatialPointsDataFrame" = spCheckAdjustProjection(x),
-              "SpatialPolygonsDataFrame" = spCheckAdjustProjection(x),
-              "SpatialLinesDataFrame" = spCheckAdjustProjection(x),
-              "SpatialPoints" = spCheckAdjustProjection(x),
-              "SpatialPolygons" = spCheckAdjustProjection(x),
-              "SpatialLines" = spCheckAdjustProjection(x),
-              "sf" = sfCheckAdjustProjection(x),
-              "XY" = sfCheckAdjustProjection(x),
-              "sfc_POINT" = sfCheckAdjustProjection(x),
-              "sfc_MULTIPOINT" = sfCheckAdjustProjection(x),
-              "sfc_LINESTRING" = sfCheckAdjustProjection(x),
-              "sfc_MULTILINESTRING" = sfCheckAdjustProjection(x),
-              "sfc_POLYGON" = sfCheckAdjustProjection(x),
-              "sfc_MULTIPOLYGON" = sfCheckAdjustProjection(x),
-              "sfc_GEOMETRY" = sfCheckAdjustProjection(x),
-              "sfc_GEOMETRYCOLLECTION" = sfCheckAdjustProjection(x))
-
-  return(x)
-
+  UseMethod("checkAdjustProjection")
 }
+
+checkAdjustProjection.RasterLayer <-
+  checkAdjustProjection.RasterStack <-
+  checkAdjustProjection.RasterBrick <- function(x, method) {
+    rasterCheckAdjustProjection(x, method)
+  }
+
+checkAdjustProjection.SpatialPointsDataFrame <-
+  checkAdjustProjection.SpatialPolygonsDataFrame <-
+  checkAdjustProjection.SpatialLinesDataFrame <-
+  checkAdjustProjection.SpatialPoints <-
+  checkAdjustProjection.SpatialPolygons <-
+  checkAdjustProjection.SpatialLines <- function(x, method) {
+    spCheckAdjustProjection(x)
+  }
+
+checkAdjustProjection.sf <-
+  checkAdjustProjection.sfc <-
+  checkAdjustProjection.sfg <- function(x, method) {
+    sfCheckAdjustProjection(x)
+  }
+
 #
 #   if (class(x)[1] %in% c("RasterLayer", "RasterStack", "RasterBrick")) {
 #     x <- rasterCheckAdjustProjection(x)


### PR DESCRIPTION
Reason: We have a package [bcdata](https://github.com/bcgov/bcdata) which returns `sf` objects but with a new class attached (`"bcdc_sf"`). This is pretty common (e.g., `tbl_df` on top of `data.frame`s). As this class appears first in the list of classes, using `switch(class(x)[1]` [here](https://github.com/r-spatial/mapview/blob/371eceb6a840fb3a8cbf7494f3b0c031cf5597ae/R/projection.R#L15) doesn't work:

    library(bcdata)
    #> 
    #> Attaching package: 'bcdata'
    #> The following object is masked from 'package:stats':
    #> 
    #>     filter
    library(mapview)
    #> GDAL version >= 3.1.0 | setting mapviewOptions(fgb = TRUE)

    dc <- bcdc_query_geodata('e3c3c580-996a-4668-8bc5-6aa7c7dc4932') %>% 
      filter(ADMIN_AREA_ABBREVIATION == "Dawson Creek") %>% 
      collect()
    #> Authorizing with your stored API key

    class(dc)
    #> [1] "bcdc_sf"    "sf"         "tbl_df"     "tbl"        "data.frame"
    mapview(dc)
    #> Error in UseMethod("st_geometry"): no applicable method for 'st_geometry' applied to an object of class "NULL"

This PR changes checkAdjustProjection to use S3 to dispatch based on the first class for which a method is defined (in this particular case, `sf`). This should make the code more robust to other packages changing the class structure of the objects.

The same approach could be made in [`mapviewHighlightOptions`](https://github.com/r-spatial/mapview/blob/74d745d24ef1b1f821a018f4902831dd5247a79d/R/mapviewHighlightOptions.R#L116-L145) as well. If you like it, I'd be happy to do a follow-up PR.

