### PR TITLE
detect ide enabling better support for VSCode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ new features:
 bugfixes:
 
   * stars image now renders correctly if supplying only a few colors. #388
+  * data now appears in maps when using default settings with VSCode R extension.
 
 ## mapview 2.10.0
 

--- a/R/print.R
+++ b/R/print.R
@@ -11,6 +11,7 @@ printMapview = function (x) {
   ## convert to leaflet object
   x = mapview2leaflet(x)
   viewer = getOption("viewer")
+  ide = get_ide()
   if (mapviewGetOption("viewer.suppress")) {
     viewer = NULL
   }
@@ -20,12 +21,22 @@ printMapview = function (x) {
       if (identical(paneHeight, "maximize")) {
         paneHeight = -1
       }
+      if (ide == "vscode") {
+        # VSCode's viewer can't ignore cross-origin requests. Need to serve the
+        # map so assests can be read, e.g. .fgb files.
+        server <- servr::httd(
+            dir = get_url_dir(url),
+            verbose = FALSE,
+            browser = FALSE
+          )
+        url <- server$url
+        
+      }
       viewer(url, height = paneHeight)
     }
   } else {
     viewerFunc = function(url) {
-      dir = gsub("file://|/index.html", "", url)
-      ide = get_ide()
+      dir = get_url_dir(url)
       switch(ide,
         "rstudio" = if (mapviewGetOption("viewer.suppress")) {
           fl = file.path(dir, "index.html")
@@ -107,3 +118,5 @@ is_vscode = function() {
     # can we find .vsc$attach() ?
     exists(".vsc") && exists("attach", envir = .vsc)
 }
+
+get_url_dir <- function(url) gsub("file://|/index.html", "", url)


### PR DESCRIPTION
- fixes #390

The root of this issue and other related issues VSCode users have been having was that the print method was detecting the user's context as RStudio due to the `{rstudioapi}` support in the VSCode-R extension (now on by default).

I have rejigged the way the `viewerFunc` works, to favour explicit detection of RStudio vs VScode (and support extension to other editors/ides should that become necessary in future). There's possibly some redundant code, but I was hoping this would make it as clear as possible where the logic for each case resides.