### PR TITLE
added SpatVector and SpatRaster methods to mapView.R

### DIFF
--- a/R/leafletControls.R
+++ b/R/leafletControls.R
@@ -184,7 +184,7 @@ removeDuplicatedMapDependencies <- function(map) {
 
 
 
-rasterCheckSize <- function(x, maxpixels) {
+rasterCheckSize<- function(x, maxpixels) {
   if (maxpixels < raster::ncell(x)) {
     warning(paste("maximum number of pixels for Raster* viewing is",
                   maxpixels, "; \nthe supplied Raster* has", ncell(x), "\n",

--- a/R/mapView.R
+++ b/R/mapView.R
@@ -377,7 +377,7 @@ setMethod('mapView', signature(x = 'RasterLayer'),
   }
 
   # convert to proper "stars" if proxy, and downscale if needed
-  if (inherits(x, "stars_proxy")) {
+  if (inherits(x, c("SpatRaster", "stars_proxy"))) {
     if (!do.downscale) {
       x <-  stars::st_as_stars(x)
     } else {
@@ -450,6 +450,10 @@ setMethod('mapView', signature(x = 'stars'), .stars_method)
 
 #' @describeIn mapView \code{stars_proxy}
 setMethod('mapView', signature(x = 'stars_proxy'), .stars_method)
+
+
+#' @describeIn mapView \code{SpatRaster}
+setMethod('mapView', signature(x = 'SpatRaster'), .stars_method)
 
 
 
@@ -587,10 +591,8 @@ setMethod('mapView', signature(x = 'Satellite'),
 ######## SIMPLE FEATURES ##################################################
 
 ## sf =====================================================================
-#' @describeIn mapView \code{\link{st_sf}}
 
-setMethod('mapView', signature(x = 'sf'),
-          function(x,
+.sf_method <- function(x,
                    map = NULL,
                    pane = "auto",
                    canvas = useCanvas(x),
@@ -619,6 +621,8 @@ setMethod('mapView', signature(x = 'sf'),
                    maxpoints = getMaxFeatures(x),
                    hide = FALSE,
                    ...) {
+
+            if(inherits(x, 'SpatVector')){x <- sf::st_as_sf(x)}
 
             if (nrow(x) == 0) {
               stop("\n", deparse(substitute(x, env = parent.frame())),
@@ -823,7 +827,14 @@ setMethod('mapView', signature(x = 'sf'),
               NULL
             }
           }
-)
+
+
+#' @describeIn mapView \code{sf}
+setMethod('mapView', signature(x = 'sf'), .sf_method)
+
+#' @describeIn mapView \code{SpatVector}
+setMethod('mapView', signature(x = 'SpatVector'), .sf_method)
+
 
 
 ## sfc ====================================================================
@@ -955,7 +966,6 @@ setMethod('mapView', signature(x = 'sfc'),
             }
           }
 )
-
 
 ## character ==============================================================
 #' @param tms whether the tiles are served as TMS tiles.

--- a/man/mapView.Rd
+++ b/man/mapView.Rd
@@ -6,9 +6,11 @@
 \alias{mapView,RasterLayer-method}
 \alias{mapView,stars-method}
 \alias{mapView,stars_proxy-method}
+\alias{mapView,SpatRaster-method}
 \alias{mapView,RasterStackBrick-method}
 \alias{mapView,Satellite-method}
 \alias{mapView,sf-method}
+\alias{mapView,SpatVector-method}
 \alias{mapView,sfc-method}
 \alias{mapView,character-method}
 \alias{mapView,numeric-method}
@@ -121,6 +123,36 @@
   ...
 )
 
+\S4method{mapView}{SpatRaster}(
+  x,
+  band = 1,
+  map = NULL,
+  maxpixels = mapviewGetOption("mapview.maxpixels"),
+  col.regions = mapviewGetOption("raster.palette"),
+  at = NULL,
+  na.color = mapviewGetOption("na.color"),
+  use.layer.names = mapviewGetOption("use.layer.names"),
+  map.types = mapviewGetOption("basemaps"),
+  alpha.regions = 0.8,
+  legend = mapviewGetOption("legend"),
+  legend.opacity = 1,
+  trim = mapviewGetOption("trim"),
+  verbose = mapviewGetOption("verbose"),
+  layer.name = NULL,
+  homebutton = mapviewGetOption("homebutton"),
+  native.crs = mapviewGetOption("native.crs"),
+  method = mapviewGetOption("method"),
+  label = TRUE,
+  query.type = mapviewGetOption("query.type"),
+  query.digits = mapviewGetOption("query.digits"),
+  query.position = mapviewGetOption("query.position"),
+  query.prefix = mapviewGetOption("query.prefix"),
+  viewer.suppress = mapviewGetOption("viewer.suppress"),
+  pane = "auto",
+  hide = FALSE,
+  ...
+)
+
 \S4method{mapView}{RasterStackBrick}(
   x,
   map = NULL,
@@ -166,6 +198,38 @@
 )
 
 \S4method{mapView}{sf}(
+  x,
+  map = NULL,
+  pane = "auto",
+  canvas = useCanvas(x),
+  viewer.suppress = mapviewGetOption("viewer.suppress"),
+  zcol = NULL,
+  burst = FALSE,
+  color = mapviewGetOption("vector.palette"),
+  col.regions = mapviewGetOption("vector.palette"),
+  at = NULL,
+  na.color = mapviewGetOption("na.color"),
+  cex = 6,
+  lwd = lineWidth(x),
+  alpha = 0.9,
+  alpha.regions = regionOpacity(x),
+  na.alpha = regionOpacity(x),
+  map.types = mapviewGetOption("basemaps"),
+  verbose = mapviewGetOption("verbose"),
+  popup = TRUE,
+  layer.name = NULL,
+  label = zcol,
+  legend = mapviewGetOption("legend"),
+  legend.opacity = 1,
+  homebutton = mapviewGetOption("homebutton"),
+  native.crs = FALSE,
+  highlight = mapviewHighlightOptions(x, alpha.regions, alpha, lwd),
+  maxpoints = getMaxFeatures(x),
+  hide = FALSE,
+  ...
+)
+
+\S4method{mapView}{SpatVector}(
   x,
   map = NULL,
   pane = "auto",
@@ -606,11 +670,15 @@ the popup will potentially still say something like "POLYGON Z".
 
 \item \code{stars_proxy}: \code{stars_proxy}
 
+\item \code{SpatRaster}: \code{SpatRaster}
+
 \item \code{RasterStackBrick}: \code{\link{stack}} / \code{\link{brick}}
 
 \item \code{Satellite}: \code{\link{satellite}}
 
-\item \code{sf}: \code{\link{st_sf}}
+\item \code{sf}: \code{sf}
+
+\item \code{SpatVector}: \code{SpatVector}
 
 \item \code{sfc}: \code{\link{st_sfc}}
 


### PR DESCRIPTION
Hey @tim-salabim, I've been running into issue #432 and thought I would take a go at adding methods for SpatRaster and SpatVector. In short, I added a `setMethod()` for both `SpatRaster` and `SpatVector` from which the functions are `.stars_method` and `sf_method`. Essentially converting to either `stars::st_as_stars('some_SpatRaster') or `sf::st_as_sf('some_SpatVector'). Hope this might be of some help... Thanks again for this great package! I use it so so much. Take care.