### PR TITLE
Fix typo "Ignord" -> "Ignored"

### DIFF
--- a/R/mapshot.R
+++ b/R/mapshot.R
@@ -171,7 +171,7 @@ mapshot = function(x,
 #' @param remove_controls \code{character} vector of control buttons to be removed
 #'   from the map when saving to file. Any combination of
 #'   "zoomControl", "layersControl", "homeButton", "scaleBar", "drawToolbar",
-#'   "easyButton". If set to \code{NULL} nothing will be removed. Ignord if \code{x}
+#'   "easyButton". If set to \code{NULL} nothing will be removed. Ignored if \code{x}
 #'   is not a mapview or leaflet map.
 #' @param ... Further arguments passed on to \code{\link[htmlwidgets]{saveWidget}}
 #'   and/or \code{\link[webshot2]{webshot}}.


### PR DESCRIPTION
Fixes typo in documentation for `@param remove_controls` in `mapview::mapshot2`. 
Changes "Ignord" -> "Ignored"