### PR TITLE
501 feature request support mapgl as a rendering platform

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -84,6 +84,7 @@ Suggests:
     leafsync,
     lwgeom,
     mapdeck,
+    mapgl,
     plainview,
     poorman,
     rmarkdown,

--- a/R/mapgl.R
+++ b/R/mapgl.R
@@ -26,6 +26,8 @@ mapgl_sf <- function(
   ...
 ) {
   # Initialize map centered on data
+  # TODO: Add switch for mapgl::mapboxgl depending on
+  # mapviewOptions("mapgl.platform") or similar
   m <- mapgl::maplibre(bounds = x)
 
   # Add source
@@ -50,7 +52,11 @@ mapgl_sf <- function(
     if (!is.null(color)) {
       color <- ifelse(is.function(color), standardColor(x), color)
     }
-    col.regions <- ifelse(is.function(col.regions), standardColRegions(x), col.regions)
+    col.regions <- ifelse(
+      is.function(col.regions),
+      standardColRegions(x),
+      col.regions
+    )
   }
 
   # Handle alpha inheritance
@@ -58,54 +64,64 @@ mapgl_sf <- function(
     na.alpha <- ifelse(na.alpha == 0, 0.001, na.alpha)
     if (length(alpha) != nrow(x)) alpha <- rep(alpha, nrow(x))
     alpha[is.na(x[[zcol]])] <- na.alpha
-    if (length(alpha.regions) != nrow(x)) alpha.regions <- rep(alpha.regions, nrow(x))
+    if (length(alpha.regions) != nrow(x))
+      alpha.regions <- rep(alpha.regions, nrow(x))
     alpha.regions[is.na(x[[zcol]])] <- na.alpha
   }
 
   # Add appropriate layers based on geometry type
   # TODO: Add support for "gc" and "rs"
-  if (geom_type == "pl") {
-    m <-
-      mapgl::add_fill_layer(
-        map = m,
-        id = "data_fill",
-        source = "data",
-        fill_color = col.regions,
-        fill_opacity = alpha.regions
-      ) |>
-      mapgl::add_line_layer(
-        id = "data_line",
-        source = "data",
-        line_color = color,
-        line_width = lwd,
-        line_opacity = alpha
-      )
-  } else if (geom_type == "ln") {
-    m <-
-      mapgl::add_line_layer(
-        map = m,
-        id = "data_line",
-        source = "data",
-        line_color = color,
-        line_width = lwd,
-        line_opacity = alpha
-      )
-  } else if (geom_type == "pt") {
-    m <-
-      mapgl::add_circle_layer(
-        map = m,
-        id = "data_point",
-        source = "data",
-        circle_opacity = alpha.regions,
-        circle_color = col.regions,
-        circle_stroke_color = color,
-        circle_stroke_width = lwd,
-        circle_radius = cex
-      )
-  }
+  m <- switch(
+    geom_type,
+    "pl" = mapgl_pl(m, col.regions, alpha.regions, color, lwd, alpha),
+    "ln" = mapgl_ln(m, color, lwd, alpha),
+    "pt" = mapgl_pt(m, alpha.regions, col.regions, color, lwd, cex)
+  )
 
   # Add navigation control
   m <- mapgl::add_navigation_control(m)
 
   return(m)
+}
+
+# Helper functions for each geometry type
+mapgl_pl <- function(m, col.regions, alpha.regions, color, lwd, alpha) {
+  mapgl::add_fill_layer(
+    map = m,
+    id = "data_fill",
+    source = "data",
+    fill_color = col.regions,
+    fill_opacity = alpha.regions
+  ) |>
+    mapgl::add_line_layer(
+      id = "data_line",
+      source = "data",
+      line_color = color,
+      line_width = lwd,
+      line_opacity = alpha
+    )
+}
+
+mapgl_ln <- function(m, color, lwd, alpha) {
+  mapgl::add_line_layer(
+    map = m,
+    id = "data_line",
+    source = "data",
+    line_color = color,
+    line_width = lwd,
+    line_opacity = alpha
+  )
+}
+
+mapgl_pt <- function(m, alpha.regions, col.regions, color, lwd, cex) {
+  mapgl::add_circle_layer(
+    map = m,
+    id = "data_point",
+    source = "data",
+    circle_opacity = alpha.regions,
+    circle_color = col.regions,
+    circle_stroke_color = color,
+    circle_stroke_width = lwd,
+    circle_radius = cex
+  )
 }

--- a/R/mapgl.R
+++ b/R/mapgl.R
@@ -1,31 +1,111 @@
-mapgl_sf = function(
-    x
-    , map
-    , zcol
-    , color
-    , col.regions
-    , at
-    , na.color
-    , cex
-    , lwd
-    , alpha
-    , alpha.regions
-    , na.alpha
-    , map.types
-    , verbose
-    , popup
-    , layer.name
-    , label
-    , legend
-    , legend.opacity
-    , homebutton
-    , native.crs
-    , highlight
-    , maxpoints
-    , viewer.suppress
-    , ...
+mapgl_sf <- function(
+  x,
+  map,
+  zcol,
+  color,
+  col.regions,
+  at,
+  na.color,
+  cex,
+  lwd,
+  alpha,
+  alpha.regions,
+  na.alpha,
+  map.types,
+  verbose,
+  popup,
+  layer.name,
+  label,
+  legend,
+  legend.opacity,
+  homebutton,
+  native.crs,
+  highlight,
+  maxpoints,
+  viewer.suppress,
+  ...
 ) {
+  # Initialize map centered on data
+  m <- mapgl::maplibre(bounds = x)
 
-  print("in the works")
+  # Add source
+  m <- mapgl::add_source(m, "data", x)
 
+  # Determine geometry type
+  geom_type <- getGeometryType(x)
+
+  # Handle color inheritance from mapview settings
+  if (geom_type %in% c("pl", "pt")) {
+    if (is.function(col.regions)) col.regions <- standardColRegions(x)
+  } else {
+    if (is.function(color)) color <- standardColor(x)
+  }
+
+  if (!is.null(zcol)) {
+    if (!is.null(color)) {
+      color <- ifelse(geom_type %in% c("pl", "pt"), standardColor(x), zcol)
+    }
+    col.regions <- ifelse(geom_type %in% c("pl", "pt"), zcol, standardColor(x))
+  } else {
+    if (!is.null(color)) {
+      color <- ifelse(is.function(color), standardColor(x), color)
+    }
+    col.regions <- ifelse(is.function(col.regions), standardColRegions(x), col.regions)
+  }
+
+  # Handle alpha inheritance
+  if (!is.null(zcol) & !is.null(na.alpha)) {
+    na.alpha <- ifelse(na.alpha == 0, 0.001, na.alpha)
+    if (length(alpha) != nrow(x)) alpha <- rep(alpha, nrow(x))
+    alpha[is.na(x[[zcol]])] <- na.alpha
+    if (length(alpha.regions) != nrow(x)) alpha.regions <- rep(alpha.regions, nrow(x))
+    alpha.regions[is.na(x[[zcol]])] <- na.alpha
+  }
+
+  # Add appropriate layers based on geometry type
+  # TODO: Add support for "gc" and "rs"
+  if (geom_type == "pl") {
+    m <-
+      mapgl::add_fill_layer(
+        map = m,
+        id = "data_fill",
+        source = "data",
+        fill_color = col.regions,
+        fill_opacity = alpha.regions
+      ) |>
+      mapgl::add_line_layer(
+        id = "data_line",
+        source = "data",
+        line_color = color,
+        line_width = lwd,
+        line_opacity = alpha
+      )
+  } else if (geom_type == "ln") {
+    m <-
+      mapgl::add_line_layer(
+        map = m,
+        id = "data_line",
+        source = "data",
+        line_color = color,
+        line_width = lwd,
+        line_opacity = alpha
+      )
+  } else if (geom_type == "pt") {
+    m <-
+      mapgl::add_circle_layer(
+        map = m,
+        id = "data_point",
+        source = "data",
+        circle_opacity = alpha.regions,
+        circle_color = col.regions,
+        circle_stroke_color = color,
+        circle_stroke_width = lwd,
+        circle_radius = cex
+      )
+  }
+
+  # Add navigation control
+  m <- mapgl::add_navigation_control(m)
+
+  return(m)
 }

--- a/R/mapgl.R
+++ b/R/mapgl.R
@@ -1,6 +1,6 @@
 mapgl_sf <- function(
   x,
-  map,
+  map = NULL,
   zcol,
   color,
   col.regions,
@@ -25,13 +25,18 @@ mapgl_sf <- function(
   viewer.suppress,
   ...
 ) {
-  # Initialize map centered on data
-  # TODO: Add switch for mapgl::mapboxgl depending on
-  # mapviewOptions("mapgl.platform") or similar
-  m <- mapgl::maplibre(bounds = x)
+  # Initialize map centered on data if no map is provided
+  if (is.null(map)) {
+    m <- mapgl::maplibre(bounds = x)
+  } else {
+    m <- map
+  }
 
-  # Add source
-  m <- mapgl::add_source(m, "data", x)
+  # Set source ID based on layer name
+  source_id <- if (!is.null(layer.name)) layer.name else "data"
+
+  # Add source with unique ID based on layer name
+  m <- mapgl::add_source(m, source_id, x)
 
   # Determine geometry type
   geom_type <- getGeometryType(x)
@@ -73,55 +78,177 @@ mapgl_sf <- function(
   # TODO: Add support for "gc" and "rs"
   m <- switch(
     geom_type,
-    "pl" = mapgl_pl(m, col.regions, alpha.regions, color, lwd, alpha),
-    "ln" = mapgl_ln(m, color, lwd, alpha),
-    "pt" = mapgl_pt(m, alpha.regions, col.regions, color, lwd, cex)
-  )
+    "pl" = mapgl_pl(
+      m,
+      source_id,
+      col.regions,
+      alpha.regions,
+      color,
+      lwd,
+      alpha
+    ),
+    "ln" = mapgl_ln(
+      m,
+      source_id,
+      color,
+      lwd,
+      alpha
+    ),
+    "pt" = mapgl_pt(
+      m,
+      source_id,
+      alpha.regions,
+      col.regions,
+      color,
+      lwd,
+      cex
+    ),
+    m
+  ) # Default case returns map unchanged
 
-  # Add navigation control
-  m <- mapgl::add_navigation_control(m)
+  # Add navigation control if this is a new map
+  if (is.null(map)) {
+    m <- mapgl::add_navigation_control(m)
+  }
 
-  return(m)
+  # Create a mapview object to support the + operator
+  # Store the original object with its name
+  if (is.null(layer.name)) {
+    layer.name <- deparse(substitute(x, env = parent.frame()))
+  }
+  out_obj <- list(x)
+  names(out_obj) <- layer.name
+
+  # Create a mapview object with the proper structure
+  out <- new("mapview", object = out_obj, map = m)
+  return(out)
+}
+
+# Implementation of the + operator for mapgl platform
+# This function combines two mapview objects by extracting and merging their maplibre calls
+mapgl_plus <- function(e1, e2) {
+  # Get the map from the first mapview object
+  m <- e1@map
+
+  # Extract the second object's source and add it to the map
+  for (name in names(e2@object)) {
+    source_id <- name
+    x <- e2@object[[name]]
+
+    # Add the source from the second object
+    m <- mapgl::add_source(m, source_id, x)
+
+    # Determine geometry type
+    geom_type <- getGeometryType(x)
+
+    # Use the same styling approach as in mapgl_sf for consistency
+
+    # FIXME:
+    # How to inherit settings from mapview objects?
+    color <- standardColor(x)
+    col.regions <- standardColRegions(x)
+    alpha <- 0.9
+    alpha.regions <- regionOpacity(x)
+    lwd <- 1
+    cex <- 6
+
+    # Add appropriate layers based on geometry type using switch
+    m <- switch(
+      geom_type,
+      "pl" = mapgl_pl(
+        m,
+        source_id,
+        col.regions,
+        alpha.regions,
+        color,
+        lwd,
+        alpha
+      ),
+      "ln" = mapgl_ln(m, source_id, color, lwd, alpha),
+      "pt" = mapgl_pt(
+        m,
+        source_id,
+        alpha.regions,
+        col.regions,
+        color,
+        lwd,
+        cex
+      ),
+      m
+    ) # Default case returns map unchanged
+  }
+
+  # Combine the objects
+  out_obj <- append(e1@object, e2@object)
+
+  # Create a new mapview object with combined objects and updated map
+  out <- new("mapview", object = out_obj, map = m)
+  return(out)
 }
 
 # Helper functions for each geometry type
-mapgl_pl <- function(m, col.regions, alpha.regions, color, lwd, alpha) {
-  mapgl::add_fill_layer(
-    map = m,
-    id = "data_fill",
-    source = "data",
-    fill_color = col.regions,
-    fill_opacity = alpha.regions
-  ) |>
-    mapgl::add_line_layer(
-      id = "data_line",
-      source = "data",
-      line_color = color,
-      line_width = lwd,
-      line_opacity = alpha
-    )
-}
+mapgl_pl <-
+  function(
+    m,
+    source_id,
+    col.regions,
+    alpha.regions,
+    color,
+    lwd,
+    alpha
+  ) {
+    m |>
+      mapgl::add_fill_layer(
+        id = paste0(source_id, "_fill"),
+        source = source_id,
+        fill_color = col.regions,
+        fill_opacity = alpha.regions
+      ) |>
+      mapgl::add_line_layer(
+        id = paste0(source_id, "_line"),
+        source = source_id,
+        line_color = color,
+        line_width = lwd,
+        line_opacity = alpha
+      )
+  }
 
-mapgl_ln <- function(m, color, lwd, alpha) {
-  mapgl::add_line_layer(
-    map = m,
-    id = "data_line",
-    source = "data",
-    line_color = color,
-    line_width = lwd,
-    line_opacity = alpha
-  )
-}
+mapgl_ln <-
+  function(
+    m,
+    source_id,
+    color,
+    lwd,
+    alpha
+  ) {
+    m |>
+      mapgl::add_line_layer(
+        id = paste0(source_id, "_line"),
+        source = source_id,
+        line_color = color,
+        line_width = lwd,
+        line_opacity = alpha
+      )
+  }
 
-mapgl_pt <- function(m, alpha.regions, col.regions, color, lwd, cex) {
-  mapgl::add_circle_layer(
-    map = m,
-    id = "data_point",
-    source = "data",
-    circle_opacity = alpha.regions,
-    circle_color = col.regions,
-    circle_stroke_color = color,
-    circle_stroke_width = lwd,
-    circle_radius = cex
-  )
-}
+mapgl_pt <-
+  function(
+    m,
+    source_id,
+    alpha.regions,
+    col.regions,
+    color,
+    lwd,
+    cex
+  ) {
+    m |>
+      mapgl::add_circle_layer(
+        id = paste0(source_id, "_point"),
+        source = source_id,
+        circle_opacity = alpha.regions,
+        circle_color = col.regions,
+        circle_stroke_color = color,
+        circle_stroke_width = lwd,
+        circle_radius = cex
+      )
+  }

--- a/R/ops.R
+++ b/R/ops.R
@@ -32,6 +32,11 @@ setMethod("+",
                     e2 = "mapview"),
           function (e1, e2) {
 
+            # Use the mapgl_plus function for mapgl platform
+            if (mapviewGetOption("platform") == "mapgl") {
+              return(mapgl_plus(e1, e2))
+            }
+
             if (mapviewGetOption("platform") %in% c("leaflet", "leafgl")) {
 
               # if (length(

--- a/inst/mapgl_dev.R
+++ b/inst/mapgl_dev.R
@@ -1,6 +1,8 @@
-library(mapview)
+# library(mapview)
+devtools::load_all()
 
 mapviewOptions(platform = "mapgl")
 
 mapview(franconia)
-
+mapview(breweries)
+mapview(trails)

--- a/inst/mapgl_dev.R
+++ b/inst/mapgl_dev.R
@@ -3,6 +3,22 @@ devtools::load_all()
 
 mapviewOptions(platform = "mapgl")
 
-mapview(franconia)
-mapview(breweries)
 mapview(trails)
+mapview(franconia)
+mapview(breweries, cex = 2)
+
+# Working
+mapview(breweries, cex = 2) +
+  mapview(franconia)
+
+# Not working
+# TODO: Need to find a way how to inherit the second layer's
+# settings
+mapview(franconia) +
+  mapview(breweries, cex = 2)
+
+# Not working
+# How to add third layer?
+mapview(franconia) +
+  mapview(breweries) +
+  mapview(trails)


### PR DESCRIPTION
This PR introduces the basic implementation of the `mapgl` backend:

- The `mapgl_sf` function handles basic spatial data visualisation of different geometry types (points, lines, polygons).
- The `+` operator has been implemented through the `mapgl_plus` function, allowing several maps to be combined together.

The main challenges are:
- Styling parameters (such as `cex` and `color`) are not being properly inherited from individual `mapview` calls for a second layer; for example, `mapview(a, cex = 2) + mapview(b)` works, but `mapview(a, cex = 2) + mapview(b, cex = 2)` does not. The issue lies in extracting styling parameters from `mapview` objects. And I need help with that.
- Layer combination works for two layers but breaks with three or more.

See `mapgl_dev.R` for a basic reprex.